### PR TITLE
[fix] 유저 인터페이스 액션 오류

### DIFF
--- a/page-src/agricola/central-board/central-board.sub/action-board/농장확장/index.tsx
+++ b/page-src/agricola/central-board/central-board.sub/action-board/농장확장/index.tsx
@@ -10,7 +10,6 @@ import { RoomWood } from '@/shared/resource/room-wood';
 import { Stone } from '@/shared/resource/stone';
 import { Wood } from '@/shared/resource/wood';
 import styled from '@emotion/styled';
-import { produce } from 'immer';
 import { ActionContainer } from 'page-src/agricola/central-board/central-board.sub/action-board/shared/components/action-container';
 import { useCurrentPlayer } from 'page-src/agricola/shared/hooks/use-current-player';
 import { useCallback, useEffect, useState } from 'react';
@@ -22,7 +21,7 @@ const ACTION_TITLE: PlayerAction = '농장 확장';
 const COUNT = 1;
 
 export const 농장확장 = () => {
-  const { currentPlayer, setPlayers, currentPlayerIndex } = useCurrentPlayer();
+  const { currentPlayer } = useCurrentPlayer();
   const [selectedPlayerNumber, setSelectedPlayerNumber] = useState<undefined | number>();
   const [, setAction] = useRecoilState(currentActionState);
   const round = useRecoilValue(roundState);
@@ -35,11 +34,6 @@ export const 농장확장 = () => {
 
     if (isValid) {
       setAction(ACTION_TITLE);
-      setPlayers(
-        produce(_players => {
-          _players[currentPlayerIndex].homeFarmer -= 1;
-        })
-      );
       setSelectedPlayerNumber(currentPlayer.number);
       return;
     }

--- a/page-src/agricola/central-board/central-board.sub/action-board/농지/index.tsx
+++ b/page-src/agricola/central-board/central-board.sub/action-board/농지/index.tsx
@@ -1,7 +1,6 @@
 import { PlayerAction, currentActionState, roundState } from '@/shared/recoil';
 import { MeepleField } from '@/shared/resource/meeple-field';
 import styled from '@emotion/styled';
-import { produce } from 'immer';
 import { ActionContainer } from 'page-src/agricola/central-board/central-board.sub/action-board/shared/components/action-container';
 import { useCurrentPlayer } from 'page-src/agricola/shared/hooks/use-current-player';
 import { useCallback, useEffect, useState } from 'react';
@@ -10,7 +9,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 const ACTION_TITLE: PlayerAction = '농지';
 
 export const 농지 = () => {
-  const { currentPlayer, setPlayers, currentPlayerIndex } = useCurrentPlayer();
+  const { currentPlayer } = useCurrentPlayer();
   const [selectedPlayerNumber, setSelectedPlayerNumber] = useState<undefined | number>();
   const [, setAction] = useRecoilState(currentActionState);
   const round = useRecoilValue(roundState);
@@ -25,17 +24,12 @@ export const 농지 = () => {
 
     if (isValid) {
       setAction(ACTION_TITLE);
-      setPlayers(
-        produce(_players => {
-          _players[currentPlayerIndex].homeFarmer -= 1;
-        })
-      );
       setSelectedPlayerNumber(currentPlayer.number);
       return;
     }
 
     alert('농지를 설치할 수 있는 칸이 없습니다.');
-  }, [selectedPlayerNumber, currentPlayer]);
+  }, [currentPlayer]);
 
   useEffect(() => {
     setSelectedPlayerNumber(undefined);

--- a/page-src/agricola/player-board/player-board.sub/empty-slot/index.tsx
+++ b/page-src/agricola/player-board/player-board.sub/empty-slot/index.tsx
@@ -72,6 +72,7 @@ export const EmptySlot = ({ width, height, index, playerNumber, children }: Prop
         if (validate(action)) {
           setPlayers(
             produce(_players => {
+              _players[ownerIndex].homeFarmer -= 1;
               _players[ownerIndex].reed -= COUNT * 2;
               _players[ownerIndex][_players[ownerIndex].roomType] -= COUNT * 5;
               _players[ownerIndex].slots = owner.slots.map((value, idx) => {
@@ -89,6 +90,7 @@ export const EmptySlot = ({ width, height, index, playerNumber, children }: Prop
       case '농지':
         setPlayers(
           produce(_players => {
+            _players[ownerIndex].homeFarmer -= 1;
             _players[ownerIndex].slots = owner.slots.map((slot, idx) => {
               if (idx === index) return { type: '밭', resource: null, count: 0 };
               return slot;

--- a/pages/agricola.tsx
+++ b/pages/agricola.tsx
@@ -1,4 +1,9 @@
-import { currentPlayerIndexState, playersState, roundState } from '@/shared/recoil';
+import {
+  currentActionState,
+  currentPlayerIndexState,
+  playersState,
+  roundState,
+} from '@/shared/recoil';
 import styled from '@emotion/styled';
 import { CentralBoard } from 'page-src/agricola/central-board';
 import { Header } from 'page-src/agricola/header';
@@ -14,6 +19,7 @@ const AgricolaPage = () => {
   const [players, setPlayers] = useRecoilState(playersState);
   const [round, setRound] = useRecoilState(roundState);
   const currentPlayerIndex = useRecoilValue(currentPlayerIndexState);
+  const action = useRecoilValue(currentActionState);
 
   const homeFarmers = players.reduce((acc, cur) => {
     return acc + cur.homeFarmer;
@@ -22,10 +28,10 @@ const AgricolaPage = () => {
   useEffect(() => {
     // 라운드가 끝났으면 다음 라운드로 넘어가기
 
-    if (homeFarmers === 0) {
+    if (homeFarmers === 0 && action === null) {
       setRound(round => round + 1);
     }
-  }, [homeFarmers]);
+  }, [homeFarmers, action]);
 
   useEffect(() => {
     /**
@@ -37,7 +43,7 @@ const AgricolaPage = () => {
     const isHarvestTime = harvest_rounds.includes(round);
 
     if (isHarvestTime) {
-      alert('가족먹여살라기 시간입니다.');
+      alert('가족먹여살리기 시간입니다.');
     }
 
     setPlayers(


### PR DESCRIPTION
## 버그 내용
**현재 라운드의 마지막 플레이어**가 `농지` / `농장 확장` 과 같은 유저 인터페이스 액션을 선택할 때, 액션 수행이 끝나지 않았음에도 바로 다음 라운드로 넘어가는 문제가 있었음
- 따라서 다음 라운드로 넘어가기 전에, 현재 수행중인 액션(`currentAction`)이 없는지 확인해야 함
    - [수정 코드](https://github.com/agricola-react/agricola-react/blob/feat/%EB%86%8D%EC%9E%A5%EA%B0%9C%EC%A1%B0/pages/agricola.tsx#L28-L34)
- 하지만 위의 `라운드 업데이트 useEffect`의 경우, 모든 유저의 `homeFarmer` 수에 의존하고 있음
    -  그런데 [유저 인터페이스 액션 코드](https://github.com/agricola-react/agricola-react/blob/feat/%EB%86%8D%EC%A7%80/page-src/agricola/player-board/player-board.sub/empty-slot/index.tsx#L90-L99)를 확인해보면 `setState`가 순차적으로 호출되고 있음 _(플레이어 정보 업데이트 -> action을 null로 변경 -> 다음 플레이어로 넘기기)_
    - 이때, `setState`는 비동기로 처리되기 때문에 순서를 보장하지 않는다.
    - 즉, `setAction(null);`이 먼저 처리되면 [수정 코드](https://github.com/agricola-react/agricola-react/blob/feat/%EB%86%8D%EC%9E%A5%EA%B0%9C%EC%A1%B0/pages/agricola.tsx#L28-L34)의 effect가 먼저 트리거 되면서 다음 라운드로 넘어갈 것이다.
        - 이렇게 되면 `setPlayer` 호출 부분이 덮어 씌어져서 변경사항이 반영되지 않는다.

## 변경사항
기존 코드에서는 액션 칸에 방문하자마자 플레이어의 `homeFarmer` 값을 조작했음.

이를 해결하기 위해 `농지` / `농장 확장` 과 같은 유저 인터페이스 액션을 선택할 때는, 
**현재 플레이어가 액션을 완전히 끝냈을 때 `homeFarmer`의 값을 조작하도록** 코드를 작성해야 한다. [액션을 완료했을 때 homeFarmer 값 수정](https://github.com/agricola-react/agricola-react/blob/feat/%EB%86%8D%EC%9E%A5%EA%B0%9C%EC%A1%B0/page-src/agricola/player-board/player-board.sub/empty-slot/index.tsx#L75)
